### PR TITLE
Pull Request

### DIFF
--- a/src/Cpu.cpp
+++ b/src/Cpu.cpp
@@ -101,7 +101,19 @@ void CPU::escalonador() {
 void CPU::executar() {
     
     int next_sched_time = 0;
-    while(1){
+
+    auto todos_finalizados = [&](){
+    bool all_exit = std::all_of(processos.begin(), processos.end(),
+        [](const Processo& p){ return p.estado == Estado::EXIT; });
+    return all_exit 
+        && running == nullptr 
+        && real_time.empty() 
+        && best_effort.empty() 
+        && waiting.empty() 
+        && newprocess.empty();
+};
+    
+    while(!todos_finalizados()){
         if((elapsed_time == next_sched_time) || this->running == nullptr || (this->running->sched == Scheduling::FCFS)){
             std::cout<< "escalonador tempo " << elapsed_time << std::endl;
             escalonador();


### PR DESCRIPTION
Implement per-process RR quantum (quantum / restante_quantum), reset on dispatch and decrement per instruction; requeue on slice end.

Enforce RR priority (0 high, 1 low) on insertion into the real-time queue.

Correct process states across lifecycle: NEW → READY → RUNNING → (WAITING | EXIT).

SYSCALL 1/2: block for 3–5 ticks and return to the original queue; SYSCALL 2 prints “Ola” when input is 101.

Use parser-decoded syscall operand (no runtime stoi).

Harden queue routing: FCFS always to/from best_effort; RR always to/from real_time; preempt FCFS when RR is available.

Guard against PC out of bounds: finalize process as EXIT instead of crashing.

.scheduling parsing: RR <n> sets quantum; prio 0|1 sets priority; arrival <t> sets admission time.

Forbid STORE in immediate mode (direct mode only).

Keep existing logs; minimal ordering tweaks to reflect corrected queues/states.